### PR TITLE
Updated Swagger/Serializer/UserLogin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # team olympian_microservice
 
 ### To Run the Program
@@ -19,3 +20,7 @@
 #### '#### Then open "http://127.0.0.1:8000/" in your browser'
 
  ![alt text](https://github.com/bauxitex3/team-olympians-company-microservice/blob/master/sample.png)
+
+# team-olympians-company-microservice
+
+


### PR DESCRIPTION
I updated the initial codes that were developed by Philemon Brian.

Added, the User Serializer

I have added the login details as well.

I also added the Swagger platform

The URL for the page is now http://127.0.0.1:8000/company/

Meanwhile, http://127.0.0.1:8000/ leads you to the staggered page.

image
![image](https://user-images.githubusercontent.com/35000589/84451079-e010aa00-ac49-11ea-9e57-4aaa94277288.png)
